### PR TITLE
Changed query.order("#{query.table_name}.key") to query.order("#{quer…

### DIFF
--- a/app/controllers/phrasing_phrases_controller.rb
+++ b/app/controllers/phrasing_phrases_controller.rb
@@ -11,7 +11,7 @@ class PhrasingPhrasesController < Phrasing.parent_controller.constantize
   def index
     params[:locale] ||= I18n.default_locale
     query = PhrasingPhrase
-    query = query.order("#{query.table_name}.key")
+    query = query.order("#{query.table_name}.[key]")
     query = query.where(locale: params[:locale]) unless params[:locale].blank?
 
     if params[:search] and !params[:search].blank?

--- a/app/controllers/phrasing_phrases_controller.rb
+++ b/app/controllers/phrasing_phrases_controller.rb
@@ -11,7 +11,7 @@ class PhrasingPhrasesController < Phrasing.parent_controller.constantize
   def index
     params[:locale] ||= I18n.default_locale
     query = PhrasingPhrase
-    query = query.order("#{query.table_name}.[key]")
+    query = query.order(:key)
     query = query.where(locale: params[:locale]) unless params[:locale].blank?
 
     if params[:search] and !params[:search].blank?


### PR DESCRIPTION
Changed query.order("#{query.table_name}.key") to query.order("#{query.table_name}.[key]") in PhrasingPhrasesController#index to fix a bug when using sql-server related to the word "key" being a tsql reserved word. I am not sure how this will affect the other databases, if at all.