### PR TITLE
Zen bubble not showing up in phrases with inverted: true

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -201,7 +201,10 @@ var editor = (function() {
 		//if any of its parents has the class of 'phrasable' go hooray
 		while ( element.parentNode ) {
 			if (element.className !== undefined){
-				if (element.className.indexOf("phrasable phrasable-on")>=0){
+				if (
+            element.className.indexOf("phrasable")>=0 &&
+            element.className.indexOf("phrasable-on")>=0
+        ){
 					return true;
 				}
 			}

--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -202,9 +202,9 @@ var editor = (function() {
 		while ( element.parentNode ) {
 			if (element.className !== undefined){
 				if (
-            element.className.indexOf("phrasable")>=0 &&
-            element.className.indexOf("phrasable-on")>=0
-        ){
+						element.className.indexOf("phrasable")>=0 &&
+						element.className.indexOf("phrasable-on")>=0
+				){
 					return true;
 				}
 			}


### PR DESCRIPTION
Hi!

When selecting text in a phrase that has `inverted:  true` the zen bubble doesn't pop up  on version 4.
This is due to a line that searches for the element's ancestor containing `phraseable phrasable-on` while a phrase with `inverted: true` has the class string set as `phrasable inverted phrasable-on` and therefor doesn't pass as a valid parent. 