### PR TITLE
Restore icomoon font-face definition

### DIFF
--- a/app/assets/stylesheets/phrasing.scss
+++ b/app/assets/stylesheets/phrasing.scss
@@ -1,6 +1,17 @@
 @import "phrasing_fonts";
 @import "phrasing_edit_mode_bubble";
 
+@font-face {
+ font-family: 'icomoon';
+ src:font-url('icomoon.eot');
+ src:font-url('icomoon.eot?#iefix') format('embedded-opentype'),
+   font-url('icomoon.woff') format('woff'),
+   font-url('icomoon.ttf') format('truetype'),
+   font-url('icomoon.svg#icomoon') format('svg');
+ font-weight: normal;
+ font-style: normal;
+}
+
 /*********************************************
  * BASE STYLES
  *********************************************/


### PR DESCRIPTION
This was lost in 8a03c910, leaving the browser not knowing which files to use for the icomoon font and thus not being able to render the link icon when editing text.

I wasn't sure where to put this. `phrasing_fonts.scss` sounds logical and that's where it previously was, but the contents of that file now don't seem very font-related, so I went with the main `phrasing.scss` file.

Thanks for phrasing!