### PR TITLE
Get rid of I18n translation missing exception in search_i18n_and_create_phrase

### DIFF
--- a/app/models/phrasing_phrase.rb
+++ b/app/models/phrasing_phrase.rb
@@ -10,9 +10,9 @@ class PhrasingPhrase < ActiveRecord::Base
 
   def self.search_i18n_and_create_phrase key
     begin
-      value = I18n.t key, raise: true
-      PhrasingPhrase.where(key: key, locale: I18n.locale).first
-    rescue I18n::MissingTranslationData
+      value = I18n.t key
+      PhrasingPhrase.where(key: key, locale: I18n.locale).first!
+    rescue ActiveRecord::RecordNotFound
       create_phrase(key)
     end
   end


### PR DESCRIPTION
Previous behavior was causing problems, because of Rails's i18n fallbacks on production:
- The translation didn't raise an exception because translation for default language was found (fallback).
- PhrasingPhrase.where(key: key, locale: I18n.locale) didn't find any phrases with non-default locale.
