### PR TITLE
Fix rails 5.2 bug

### DIFF
--- a/app/models/phrasing_phrase.rb
+++ b/app/models/phrasing_phrase.rb
@@ -4,7 +4,7 @@ class PhrasingPhrase < ActiveRecord::Base
   # validate :uniqueness_of_key_on_locale_scope, on: :create
   validates_uniqueness_of :key, scope: [:locale]
 
-  has_many :versions, dependent: :destroy, class_name: PhrasingPhraseVersion
+  has_many :versions, dependent: :destroy, class_name: 'PhrasingPhraseVersion'
 
   after_update :version_it
 


### PR DESCRIPTION
Rails 5.2 raises error when `class_name: ` receives a constant. Instead it should receive a string.

Rails <5.2:
> DEPRECATION WARNING: Passing a class to the `class_name` is deprecated and will raise an ArgumentError in Rails 5.2. It eagerloads more classes than necessary and potentially creates circular dependencies. Please pass the class name as a string: `has_many :tags, class_name: 'ActsAsTaggableOn::Tag'`

Rails 5.2:
> ArgumentError: A class was passed to `:class_name` but we are expecting a string.