### PR TITLE
Feature/linear gradient wc3

### DIFF
--- a/app/assets/stylesheets/phrasing_engine.css
+++ b/app/assets/stylesheets/phrasing_engine.css
@@ -137,7 +137,7 @@
     background: #eee -webkit-linear-gradient(top, rgba(255,255,255,.2) 0%,rgba(0,0,0,.2) 100%); /* Chrome10+,Safari5.1+ */
     background: #eee -o-linear-gradient(top, rgba(255,255,255,.2) 0%,rgba(0,0,0,.2) 100%); /* Opera11.10+ */
     background: #eee -ms-linear-gradient(top, rgba(255,255,255,.2) 0%,rgba(0,0,0,.2) 100%); /* IE10+ */
-    background: #eee linear-gradient(top, rgba(255,255,255,.2) 0%,rgba(0,0,0,.2) 100%); /* W3C */
+    background: #eee linear-gradient(to bottom, rgba(255,255,255,.2) 0%,rgba(0,0,0,.2) 100%); /* W3C */
     border: 1px solid #aaa;
     border-top: 1px solid #ccc;
     border-left: 1px solid #ccc;
@@ -168,7 +168,7 @@
     background: #ddd -webkit-linear-gradient(top, rgba(255,255,255,.3) 0%,rgba(0,0,0,.3) 100%); /* Chrome10+,Safari5.1+ */
     background: #ddd -o-linear-gradient(top, rgba(255,255,255,.3) 0%,rgba(0,0,0,.3) 100%); /* Opera11.10+ */
     background: #ddd -ms-linear-gradient(top, rgba(255,255,255,.3) 0%,rgba(0,0,0,.3) 100%); /* IE10+ */
-    background: #ddd linear-gradient(top, rgba(255,255,255,.3) 0%,rgba(0,0,0,.3) 100%); /* W3C */
+    background: #ddd linear-gradient(to bottom, rgba(255,255,255,.3) 0%,rgba(0,0,0,.3) 100%); /* W3C */
     border: 1px solid #888;
     border-top: 1px solid #aaa;
     border-left: 1px solid #aaa; }
@@ -184,7 +184,7 @@
     background: #ccc -webkit-linear-gradient(top, rgba(255,255,255,.35) 0%,rgba(10,10,10,.4) 100%); /* Chrome10+,Safari5.1+ */
     background: #ccc -o-linear-gradient(top, rgba(255,255,255,.35) 0%,rgba(10,10,10,.4) 100%); /* Opera11.10+ */
     background: #ccc -ms-linear-gradient(top, rgba(255,255,255,.35) 0%,rgba(10,10,10,.4) 100%); /* IE10+ */
-    background: #ccc linear-gradient(top, rgba(255,255,255,.35) 0%,rgba(10,10,10,.4) 100%); /* W3C */ }
+    background: #ccc linear-gradient(to bottom, rgba(255,255,255,.35) 0%,rgba(10,10,10,.4) 100%); /* W3C */ }
 
   .button.full-width,
   button.full-width,

--- a/lib/phrasing/version.rb
+++ b/lib/phrasing/version.rb
@@ -1,3 +1,3 @@
 module Phrasing
-  VERSION = '4.2.0'.freeze
+  VERSION = '4.2.1'.freeze
 end


### PR DESCRIPTION
This PR fixes outdated linear-gradient syntax, which Autoprefixer-Rails complains about.

https://www.w3.org/TR/css3-images/#linear-gradients

`autoprefixer: vendor/bundle/ruby/2.2.0/gems/phrasing-4.2.0/app/assets/stylesheets/phrasing_engine.css:141:5: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: vendor/bundle/ruby/2.2.0/gems/phrasing-4.2.0/app/assets/stylesheets/phrasing_engine.css:172:5: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
autoprefixer: vendor/bundle/ruby/2.2.0/gems/phrasing-4.2.0/app/assets/stylesheets/phrasing_engine.css:188:5: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.
 `