### PR TITLE
Feature/default phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ You can start adding new phrases by simply adding them in your view file:
 
 	<%= phrase('my-first-phrase') %>
 
+If you want the key not to be the default phrase, you can define one like here:
+
+	<%= phrase('my-first-phrase',default: 'default phrase') %>
+
 Aside from editing phrases (basically, Rails translations) you can also edit model attributes inline. Use the same `phrase` method, with the first attribute being the record in question, and the second one the attribute you wish to make editable:
 
     <%= phrase(@post, :title) %>

--- a/app/helpers/inline_helper.rb
+++ b/app/helpers/inline_helper.rb
@@ -32,7 +32,7 @@ module InlineHelper
 
   def phrasing_extract_record(key, options = {})
     key = options[:scope] ? "#{options[:scope]}.#{key}" : key
-    PhrasingPhrase.find_phrase(key)
+    PhrasingPhrase.find_phrase(key,options[:default])
   end
 
   def uneditable_phrase(record, attribute)

--- a/app/models/phrasing_phrase.rb
+++ b/app/models/phrasing_phrase.rb
@@ -41,7 +41,7 @@ class PhrasingPhrase < ActiveRecord::Base
       phrasing_phrase = PhrasingPhrase.new
       phrasing_phrase.locale = I18n.locale.to_s
       phrasing_phrase.key    = key.to_s
-      phrasing_phrase.value  = value || default.to_s
+      phrasing_phrase.value  = value || default.to_s || key.to_s
       phrasing_phrase.save
       phrasing_phrase
     end

--- a/app/models/phrasing_phrase.rb
+++ b/app/models/phrasing_phrase.rb
@@ -8,8 +8,8 @@ class PhrasingPhrase < ActiveRecord::Base
 
   after_update :version_it
 
-  def self.find_phrase(key)
-    where(key: key, locale: I18n.locale.to_s).first || search_i18n_and_create_phrase(key)
+  def self.find_phrase(key,default=nil)
+    where(key: key, locale: I18n.locale.to_s).first || search_i18n_and_create_phrase(key,default)
   end
 
   def self.fuzzy_search(search_term, locale)
@@ -28,20 +28,20 @@ class PhrasingPhrase < ActiveRecord::Base
 
   private
 
-    def self.search_i18n_and_create_phrase(key)
+    def self.search_i18n_and_create_phrase(key,default=nil)
       begin
         value = I18n.t(key, raise: true)
         create_phrase(key, value)
       rescue I18n::MissingTranslationData
-        create_phrase(key)
+        create_phrase(key,nil,default)
       end
     end
 
-    def self.create_phrase(key, value=nil)
+    def self.create_phrase(key,value=nil, default='empty' )
       phrasing_phrase = PhrasingPhrase.new
       phrasing_phrase.locale = I18n.locale.to_s
       phrasing_phrase.key    = key.to_s
-      phrasing_phrase.value  = value || key.to_s
+      phrasing_phrase.value  = value || default.to_s
       phrasing_phrase.save
       phrasing_phrase
     end

--- a/app/models/phrasing_phrase.rb
+++ b/app/models/phrasing_phrase.rb
@@ -37,11 +37,11 @@ class PhrasingPhrase < ActiveRecord::Base
       end
     end
 
-    def self.create_phrase(key,value=nil, default='empty' )
+    def self.create_phrase(key,value=nil, default=nil )
       phrasing_phrase = PhrasingPhrase.new
       phrasing_phrase.locale = I18n.locale.to_s
       phrasing_phrase.key    = key.to_s
-      phrasing_phrase.value  = value || default.to_s || key.to_s
+      phrasing_phrase.value  = value || default || key.to_s
       phrasing_phrase.save
       phrasing_phrase
     end


### PR DESCRIPTION
Adds a default option for normal phrases. 

If you want to change the default later on, but keep the already set up phrases intact.

In my case... I create multiple versions of the same phrase, with a default phrase that may be changed later on. I can't use the key as a default, because if I change it, it resets all other versions back to default, because the key is different. With a default phrase I can change it as often as I like without touching the key.